### PR TITLE
OpenAI Provider Refactoring

### DIFF
--- a/ai/llm_provider_openai.go
+++ b/ai/llm_provider_openai.go
@@ -6,30 +6,47 @@ import (
 	"time"
 
 	"github.com/openai/openai-go"
-	"github.com/openai/openai-go/option"
 )
 
-// OpenAILLMProvider implements the LLMProvider interface using the official OpenAI SDK
+// OpenAILLMProvider implements the LLMProvider interface using OpenAI's official SDK.
 type OpenAILLMProvider struct {
-	client *openai.Client
-	model  openai.ChatModel
+	client OpenAIClient
+	model  string
 }
 
-// OpenAIProviderConfig holds configuration for OpenAI provider
+// OpenAIProviderConfig holds configuration for OpenAI provider.
 type OpenAIProviderConfig struct {
-	APIKey string
-	Model  openai.ChatModel
+	// Client is the OpenAIClient implementation to use
+	Client OpenAIClient
+	// Model specifies which OpenAI model to use (e.g., "gpt-4", "gpt-3.5-turbo")
+	Model string
 }
 
 // NewOpenAILLMProvider creates a new OpenAI provider with the specified configuration.
 // If no model is specified, it defaults to GPT-3.5-turbo.
+//
+// Example usage:
+//
+//	// Create client
+//	client := NewRealOpenAIClient("your-api-key")
+//
+//	// Create provider with default model
+//	provider := NewOpenAILLMProvider(OpenAIProviderConfig{
+//	    Client: client,
+//	})
+//
+//	// Create provider with specific model
+//	provider := NewOpenAILLMProvider(OpenAIProviderConfig{
+//	    Client: client,
+//	    Model:  "gpt-4",
+//	})
 func NewOpenAILLMProvider(config OpenAIProviderConfig) *OpenAILLMProvider {
 	if config.Model == "" {
-		config.Model = openai.ChatModelGPT3_5Turbo
+		config.Model = string(openai.ChatModelGPT3_5Turbo)
 	}
 
 	return &OpenAILLMProvider{
-		client: openai.NewClient(option.WithAPIKey(config.APIKey)),
+		client: config.Client,
 		model:  config.Model,
 	}
 }
@@ -65,13 +82,26 @@ func (p *OpenAILLMProvider) createCompletionParams(messages []openai.ChatComplet
 
 // GetResponse generates a response using OpenAI's API for the given messages and configuration.
 // It supports different message roles (user, assistant, system) and handles them appropriately.
+//
+// Example usage:
+//
+//	messages := []ai.LLMMessage{
+//	    {Role: "system", Text: "You are a helpful assistant"},
+//	    {Role: "user", Text: "What is the capital of France?"},
+//	}
+//
+//	response, err := provider.GetResponse(messages, config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Printf("Response: %s\n", response.Text)
 func (p *OpenAILLMProvider) GetResponse(messages []LLMMessage, config LLMRequestConfig) (LLMResponse, error) {
 	startTime := time.Now()
 
 	openAIMessages := p.convertToOpenAIMessages(messages)
 	params := p.createCompletionParams(openAIMessages, config)
 
-	completion, err := p.client.Chat.Completions.New(context.Background(), params)
+	completion, err := p.client.CreateCompletion(context.Background(), params)
 	if err != nil {
 		return LLMResponse{}, err
 	}
@@ -90,11 +120,26 @@ func (p *OpenAILLMProvider) GetResponse(messages []LLMMessage, config LLMRequest
 
 // GetStreamingResponse generates a streaming response using OpenAI's API.
 // It supports streaming tokens as they're generated and handles context cancellation.
+//
+// Example usage:
+//
+//	stream, err := provider.GetStreamingResponse(ctx, messages, config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	for response := range stream {
+//	    if response.Error != nil {
+//	        log.Printf("Error: %v", response.Error)
+//	        break
+//	    }
+//	    fmt.Print(response.Text)
+//	}
 func (p *OpenAILLMProvider) GetStreamingResponse(ctx context.Context, messages []LLMMessage, config LLMRequestConfig) (<-chan StreamingLLMResponse, error) {
 	openAIMessages := p.convertToOpenAIMessages(messages)
 	params := p.createCompletionParams(openAIMessages, config)
 
-	stream := p.client.Chat.Completions.NewStreaming(ctx, params)
+	stream := p.client.CreateStreamingCompletion(ctx, params)
 	responseChan := make(chan StreamingLLMResponse, 100)
 
 	go func() {

--- a/ai/llm_provider_openai_client.go
+++ b/ai/llm_provider_openai_client.go
@@ -1,0 +1,56 @@
+// Package ai provides a flexible interface for interacting with various Language Learning Models (LLMs).
+package ai
+
+import (
+	"context"
+
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/packages/ssestream"
+)
+
+// OpenAIClient defines the interface for interacting with OpenAI's API.
+// This interface abstracts the essential operations used by OpenAILLMProvider.
+type OpenAIClient interface {
+	// CreateCompletion creates a new chat completion using OpenAI's API.
+	CreateCompletion(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error)
+
+	// CreateStreamingCompletion creates a streaming chat completion using OpenAI's API.
+	CreateStreamingCompletion(ctx context.Context, params openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk]
+}
+
+// RealOpenAIClient implements the OpenAIClient interface using OpenAI's official SDK.
+type RealOpenAIClient struct {
+	client *openai.Client
+}
+
+// NewRealOpenAIClient creates a new instance of RealOpenAIClient with the provided API key
+// and optional client options.
+//
+// Example usage:
+//
+//	// Basic usage with API key
+//	client := NewRealOpenAIClient("your-api-key")
+//
+//	// Usage with custom HTTP client
+//	httpClient := &http.Client{Timeout: 30 * time.Second}
+//	client := NewRealOpenAIClient(
+//	    "your-api-key",
+//	    option.WithHTTPClient(httpClient),
+//	)
+func NewRealOpenAIClient(apiKey string, opts ...option.RequestOption) *RealOpenAIClient {
+	opts = append(opts, option.WithAPIKey(apiKey))
+	return &RealOpenAIClient{
+		client: openai.NewClient(opts...),
+	}
+}
+
+// CreateCompletion implements the OpenAIClient interface using the real OpenAI client.
+func (c *RealOpenAIClient) CreateCompletion(ctx context.Context, params openai.ChatCompletionNewParams) (*openai.ChatCompletion, error) {
+	return c.client.Chat.Completions.New(ctx, params)
+}
+
+// CreateStreamingCompletion implements the streaming support for the OpenAIClient interface.
+func (c *RealOpenAIClient) CreateStreamingCompletion(ctx context.Context, params openai.ChatCompletionNewParams) *ssestream.Stream[openai.ChatCompletionChunk] {
+	return c.client.Chat.Completions.NewStreaming(ctx, params)
+}


### PR DESCRIPTION
This pull request includes significant changes to the OpenAI LLM provider implementation and its tests. The main changes involve refactoring the client structure, adding example usage comments, and updating the tests to use a mock client.

### Refactoring and improvements:

* [`ai/llm_provider_openai.go`](diffhunk://#diff-06d32109cc20281d475f9551678757c6ac1e82748c2475ecbb8022d772d9684eL9-R49): Refactored the `OpenAILLMProvider` structure to use an `OpenAIClient` interface instead of the `openai.Client` type directly, and added example usage comments for better clarity. [[1]](diffhunk://#diff-06d32109cc20281d475f9551678757c6ac1e82748c2475ecbb8022d772d9684eL9-R49) [[2]](diffhunk://#diff-06d32109cc20281d475f9551678757c6ac1e82748c2475ecbb8022d772d9684eR85-R104) [[3]](diffhunk://#diff-06d32109cc20281d475f9551678757c6ac1e82748c2475ecbb8022d772d9684eR123-R142)

### Testing enhancements:

* [`ai/llm_provider_openai_test.go`](diffhunk://#diff-558a2c4021c22637bd008e387080ab86a6f8e5ba16d627360086cdc8dcb25d58R12-R66): Introduced a `MockOpenAIClient` to facilitate testing, and updated the tests to use this mock client. This includes creating mock streaming responses for testing streaming functionality. [[1]](diffhunk://#diff-558a2c4021c22637bd008e387080ab86a6f8e5ba16d627360086cdc8dcb25d58R12-R66) [[2]](diffhunk://#diff-558a2c4021c22637bd008e387080ab86a6f8e5ba16d627360086cdc8dcb25d58L23-R83) [[3]](diffhunk://#diff-558a2c4021c22637bd008e387080ab86a6f8e5ba16d627360086cdc8dcb25d58L79-R140) [[4]](diffhunk://#diff-558a2c4021c22637bd008e387080ab86a6f8e5ba16d627360086cdc8dcb25d58L113-L140)